### PR TITLE
candle-flash-attn: remove duplicate `softcap: f32` in run_mha FFI decl

### DIFF
--- a/candle-core/src/npy.rs
+++ b/candle-core/src/npy.rs
@@ -117,11 +117,9 @@ impl Header {
             match c {
                 '(' => cnt_parenthesis += 1,
                 ')' => cnt_parenthesis -= 1,
-                ',' => {
-                    if cnt_parenthesis == 0 {
-                        parts.push(header[start_index..index].to_owned());
-                        start_index = index + 1;
-                    }
+                ',' if cnt_parenthesis == 0 => {
+                    parts.push(header[start_index..index].to_owned());
+                    start_index = index + 1;
                 }
                 _ => {}
             }

--- a/candle-examples/examples/quantized-lfm2/main.rs
+++ b/candle-examples/examples/quantized-lfm2/main.rs
@@ -297,6 +297,7 @@ fn main() -> Result<()> {
     let eos_token = guess_eos_id(tos.tokenizer());
     let mut sampled = 0;
     let start_post_prompt = std::time::Instant::now();
+    #[allow(clippy::explicit_counter_loop)]
     for _ in 0..to_sample {
         if let Some(max_ctx) = context_length {
             if index_pos + 1 > max_ctx {

--- a/candle-flash-attn/src/ffi.rs
+++ b/candle-flash-attn/src/ffi.rs
@@ -34,7 +34,6 @@ extern "C" {
         d: u32,
         d_rounded: u32,
         softmax_scale: f32,
-        softcap: f32,
 
         seqlen_q: u32,
         seqlen_k: u32,

--- a/candle-transformers/src/models/fastvit.rs
+++ b/candle-transformers/src/models/fastvit.rs
@@ -197,11 +197,7 @@ fn mobileone_block(
     use_act: bool,
     vb: VarBuilder,
 ) -> Result<Func<'static>> {
-    let groups = if group_size == 0 {
-        1
-    } else {
-        in_channels / group_size
-    };
+    let groups = in_channels.checked_div(group_size).unwrap_or(1);
 
     let padding = kernel / 2;
     let conv2d_cfg = Conv2dConfig {

--- a/candle-transformers/src/models/paddleocr_vl/mod.rs
+++ b/candle-transformers/src/models/paddleocr_vl/mod.rs
@@ -538,6 +538,7 @@ impl PaddleOCRVLModel {
         current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
 
         // Subsequent forward passes (text only, using KV cache)
+        #[allow(clippy::explicit_counter_loop)]
         for _ in 1..max_new_tokens {
             let logits = self.forward(&current_ids, None, None, seqlen_offset)?;
             let next_token = logits
@@ -600,6 +601,7 @@ impl PaddleOCRVLModel {
 
         // Subsequent forward passes (text only, using KV cache)
         // Uses same incremental decoding as single-image generation
+        #[allow(clippy::explicit_counter_loop)]
         for _ in 1..max_new_tokens {
             let logits = self.forward(&current_ids, None, None, seqlen_offset)?;
             let next_token = logits
@@ -665,6 +667,7 @@ impl PaddleOCRVLModel {
         current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
 
         // Subsequent forward passes (text only, using KV cache)
+        #[allow(clippy::explicit_counter_loop)]
         for _ in 1..max_new_tokens {
             let logits = self.forward(&current_ids, None, None, seqlen_offset)?;
             let next_token = logits
@@ -871,6 +874,7 @@ impl PaddleOCRVLModel {
         current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
 
         // Subsequent forward passes (text only, using KV cache)
+        #[allow(clippy::explicit_counter_loop)]
         for _ in 1..max_new_tokens {
             let logits = self.forward(&current_ids, None, None, seqlen_offset)?;
             let logits = apply_repetition_penalty(&logits, &generated_tokens, repetition_penalty)?;
@@ -1047,6 +1051,7 @@ impl PaddleOCRVLModel {
         let mut seqlen_offset = input_ids.dim(1)?;
         let mut current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
 
+        #[allow(clippy::explicit_counter_loop)]
         for step in 1..max_steps {
             // Compute position for M-RoPE
             let pos = seqlen_offset as i64 + self.mrope_position_delta;

--- a/candle-transformers/src/models/stella_en_v5.rs
+++ b/candle-transformers/src/models/stella_en_v5.rs
@@ -288,11 +288,7 @@ impl Attention {
         let hidden_sz = cfg.hidden_size;
         let num_heads = cfg.num_attention_heads;
         let num_kv_heads = cfg.num_key_value_heads;
-        let num_kv_groups = if num_kv_heads > 0 {
-            num_heads / num_kv_heads
-        } else {
-            0
-        };
+        let num_kv_groups = num_heads.checked_div(num_kv_heads).unwrap_or(0);
         let head_dim = hidden_sz / num_heads;
 
         let (qkv_proj, o_proj) = match cfg.variant {


### PR DESCRIPTION
The Rust extern declaration of `run_mha` in `candle-flash-attn/src/ffi.rs` listed `softcap: f32` twice — once between `softmax_scale` and `seqlen_q`, and again at the end of the parameter list (after `window_size_right`).

The C definition in `candle-flash-attn/kernels/flash_api.cu` only has a single `softcap` (at the end):

```cpp
extern "C" void run_mha(
    ...
    float softmax_scale,
    uint32_t seqlen_q,
    ...
    int window_size_left,
    int window_size_right,
    float softcap
) { ... }
```

so the Rust-side signature declared 38 parameters while the call sites in `src/lib.rs` pass 37:

```
error[E0061]: this function takes 38 arguments but 37 arguments were supplied
   --> candle-flash-attn/src/lib.rs:169:13
error[E0061]: this function takes 38 arguments but 37 arguments were supplied
   --> candle-flash-attn/src/lib.rs:634:13
```

Drop the spurious copy between `softmax_scale` and `seqlen_q` so the Rust FFI matches the C ABI.

## Validation

Reproduced while building `spiced` ([spiceai/spiceai#10278](https://github.com/spiceai/spiceai/pull/10278)) with `--features cuda` on CUDA 12.6 — the build now completes once this fix is applied.
