### PR TITLE
Rename candle's moe_gemm_wmma → candle_moe_gemm_wmma to avoid symbol collision with mistralrs-core

### DIFF
--- a/candle-kernels/src/ffi.rs
+++ b/candle-kernels/src/ffi.rs
@@ -2,7 +2,7 @@ use core::ffi::c_void;
 #[allow(dead_code)]
 extern "C" {
     // for unquntized models
-    pub fn moe_gemm_wmma(
+    pub fn candle_moe_gemm_wmma(
         input: *const c_void,         // device pointer [size_m, size_k]
         weights: *const c_void,       // device pointer [num_experts, size_n, size_k]
         sorted_token_ids: *const i32, // device pointer [size_m]

--- a/candle-kernels/src/moe/moe_wmma.cu
+++ b/candle-kernels/src/moe/moe_wmma.cu
@@ -231,7 +231,7 @@ __global__ void moe_gemm_grouped_kernel(
         size_m, size_n, size_k \
     );\
 
-extern "C" void moe_gemm_wmma(
+extern "C" void candle_moe_gemm_wmma(
     const void* input,                // [size_m, size_k]
     const void* weights,              // [num_experts, size_n, size_k]
     const int32_t* sorted_token_ids,  // [size_m] (Device)

--- a/candle-nn/src/moe.rs
+++ b/candle-nn/src/moe.rs
@@ -94,7 +94,7 @@ pub fn moe_gemm(
         use core::ffi::c_void;
 
         unsafe {
-            ffi::moe_gemm_wmma(
+            ffi::candle_moe_gemm_wmma(
                 input.device_ptr(input.stream()).0 as *const c_void, // [size_m, size_k]
                 weights.device_ptr(weights.stream()).0 as *const c_void, // [num_experts, size_n, size_k]
                 sorted_token_ids.device_ptr(sorted_token_ids.stream()).0 as *const i32,


### PR DESCRIPTION
## Problem

Linking `spiced` with `--features cuda,models` fails with:

```
ld.lld: error: duplicate symbol: moe_gemm_wmma
  >>> defined in candle-kernels/out/libmoe.a (moe_wmma.cu)
  >>> defined in mistralrs-core/out/libmistralrscuda.a (moe_gemm_wmma.cu)
```

Both crates independently adapted the MoE WMMA kernel from [guoqingbao/attention.rs](https://github.com/guoqingbao/attention.rs) and export it with the same `extern "C"` name. When both crates are linked into the same binary (Spice.ai runtime uses candle for embeddings/TEI and mistral.rs for LLM inference), ld.lld rejects the duplicate symbol.

## Fix

Prefix the **candle side** of the symbol with `candle_` so both kernels can coexist at link time:

- `candle-kernels/src/moe/moe_wmma.cu`: `extern "C" void moe_gemm_wmma` → `extern "C" void candle_moe_gemm_wmma`
- `candle-kernels/src/ffi.rs`: FFI declaration updated to match
- `candle-nn/src/moe.rs`: call site updated to match

The `mistralrs-core` copy (which also has a `moe_gemm_wmma_transposed` variant unique to it) keeps its original name.

## Scope

- No semantic change to the kernel implementation
- Only candle's own crates call `candle-kernels::ffi::moe_gemm_wmma`; no external callers affected
- The human-readable error string in `candle-nn/src/moe.rs` and the upstream-URL comment in `moe_wmma.cu` intentionally preserve the original `moe_gemm_wmma` name (they refer to the upstream author's name, not our symbol).

## Verification

Local build of `spiced --features cuda,models` on CUDA 12.6 / sm_90 (H100) links cleanly after this change is applied via workspace `[patch]`. Will re-verify with the merged SHA once this lands.